### PR TITLE
Fixes the current quote check

### DIFF
--- a/app/code/community/ADM/AbandonedCart/Model/Followup.php
+++ b/app/code/community/ADM/AbandonedCart/Model/Followup.php
@@ -130,11 +130,16 @@ class ADM_AbandonedCart_Model_Followup extends Mage_Core_Model_Abstract
     protected function _getCurrentQuoteId()
     {
         $checkoutSession = Mage::getSingleton('checkout/session');
-        if($checkoutSession->hasQuote()) {
-            return $checkoutSession->getQuoteId();
-        } else {
-            return false;
+        $quoteId = $checkoutSession->getQuoteId();
+        if ($quoteId) {
+            return $quoteId;
         }
+        
+        if ($checkoutSession->hasQuote()) {
+            return $checkoutSession->getQuote()->getId();
+        }
+
+        return false;
     }
 
 


### PR DESCRIPTION
The Mage_Checkout_Model_Session::hasQuote() method is implemented in a very crude way. It simply checks whether the session field _quote is empty or not. That field, in turn, is populated from the real session data when the Mage_Checkout_Model_Session::getQuote() is first called.
The issue is that when one follows a restore link in a mail, he/she may get to this _getCurrentQuoteId() method without the Mage_Checkout_Model_Session::getQuote() method ever having been called. Therefore the _quote field in the checkout session will always be empty and the Mage_Checkout_Model_Session::hasQuote() will always return false.

This PR should fix this. It checks the quoteId value in the session, which should always be there if there is an active quote (regardless of whether the getQuote() method has been called or not).
If that check fails, it tries to see of there is a quote object in the session (perhaps some extension injects a quote object without setting the quoteId value?)
And finally, if the second check fails as well, then the method gives up.