### PR TITLE
Uses the UTC timezone for the dates

### DIFF
--- a/app/code/community/ADM/AbandonedCart/Model/Resource/Followup.php
+++ b/app/code/community/ADM/AbandonedCart/Model/Resource/Followup.php
@@ -57,6 +57,7 @@ class ADM_AbandonedCart_Model_Resource_Followup extends Mage_Core_Model_Resource
     protected function _getDateSubTime($nbr, $type = Zend_Date::HOUR)
     {
         $date  = Mage::app()->getLocale()->date()
+        ->setTimezone(Mage_Core_Model_Locale::DEFAULT_TIMEZONE)
         ->sub($nbr, $type)
         ->toString(Varien_Date::DATETIME_INTERNAL_FORMAT);
 
@@ -66,6 +67,7 @@ class ADM_AbandonedCart_Model_Resource_Followup extends Mage_Core_Model_Resource
     protected function _getDateAddTime($nbr, $type = Zend_Date::HOUR)
     {
         $date  = Mage::app()->getLocale()->date()
+        ->setTimezone(Mage_Core_Model_Locale::DEFAULT_TIMEZONE)
         ->add($nbr, $type)
         ->toString(Varien_Date::DATETIME_INTERNAL_FORMAT);
 

--- a/app/code/community/ADM/AbandonedCart/Model/Resource/Followup.php
+++ b/app/code/community/ADM/AbandonedCart/Model/Resource/Followup.php
@@ -41,7 +41,7 @@ class ADM_AbandonedCart_Model_Resource_Followup extends Mage_Core_Model_Resource
                         'currency' => $quote->getQuoteCurrencyCode(),
                         'base_grand_total'=>$quote->getBaseGrandTotal(),
                         'coupon_code'=>$quote->getCouponCode(),
-                        'mail_scheduled_at'=>Varien_Date::now()
+                        'mail_scheduled_at'=>Mage::getModel('core/date')->gmtDate()
                         );
             }
 

--- a/app/code/community/ADM/AbandonedCart/Model/Resource/Followup/Collection.php
+++ b/app/code/community/ADM/AbandonedCart/Model/Resource/Followup/Collection.php
@@ -15,7 +15,7 @@ class ADM_AbandonedCart_Model_Resource_Followup_Collection extends Mage_Core_Mod
 
         $this->addFieldToFilter('status', array('lteq'=>0))
             ->addFieldToFilter('offset', array('lt'=>Mage::helper('adm_abandonedcart')->getMaxOffset()))
-            ->addFieldToFilter('mail_scheduled_at', array('lteq'=>Mage::app()->getLocale()->date()->toString(Varien_Date::DATETIME_INTERNAL_FORMAT)));
+            ->addFieldToFilter('mail_scheduled_at', array('lteq' => Mage::getModel('core/date')->gmtDate()));
 
         $this->getSelect()->join(array('quote'=>$this->getTable('sales/quote')), 'main_table.quote_id=quote.entity_id', array('quote_still_active'=>'is_active'));
 


### PR DESCRIPTION
Magento saves most dates (including the quote's updated_at field) in the UTC timezone. Therefore any check on the quote's updated_at field must use values in the same timezone, otherwise wrong results will be obtained.

I tried to replace the call to date() with a call to utcdate(), but that didn't seem to work. That's why in the PR I set the timezone after the fact.