### PR TITLE
Fixes an off-by-one error in the handling of the delay configurations

### DIFF
--- a/app/code/community/ADM/AbandonedCart/Model/Followup.php
+++ b/app/code/community/ADM/AbandonedCart/Model/Followup.php
@@ -305,7 +305,9 @@ class ADM_AbandonedCart_Model_Followup extends Mage_Core_Model_Abstract
     protected function _beforeSave()
     {
         if($this->getMailSent()) {
-            $this->setMailScheduledAt($this->_getNextDate());
+            if ($this->getOffset() < 2) {
+                $this->setMailScheduledAt($this->_getNextDate());
+            }
             $this->setOffset($this->getOffset()+1);
         }
 
@@ -322,8 +324,8 @@ class ADM_AbandonedCart_Model_Followup extends Mage_Core_Model_Abstract
 
     protected function _getNextDate()
     {
-        $delayCurrent = Mage::helper('adm_abandonedcart')->getConfigByOffset('delay', $this->getOrigData('offset'), $this->getStoreId());
-        $delayNext    = Mage::helper('adm_abandonedcart')->getConfigByOffset('delay', $this->getOrigData('offset')+1, $this->getStoreId());
+        $delayCurrent = Mage::helper('adm_abandonedcart')->getConfigByOffset('delay', $this->getOrigData('offset')+1, $this->getStoreId());
+        $delayNext    = Mage::helper('adm_abandonedcart')->getConfigByOffset('delay', $this->getOrigData('offset')+2, $this->getStoreId());
 
         $delayReal = $delayNext-$delayCurrent;
 

--- a/app/code/community/ADM/AbandonedCart/Model/Followup.php
+++ b/app/code/community/ADM/AbandonedCart/Model/Followup.php
@@ -305,7 +305,7 @@ class ADM_AbandonedCart_Model_Followup extends Mage_Core_Model_Abstract
     protected function _beforeSave()
     {
         if($this->getMailSent()) {
-            if ($this->getOffset() < 2) {
+            if ($this->getOffset() < Mage::helper('adm_abandonedcart')->getMaxOffset()-1) {
                 $this->setMailScheduledAt($this->_getNextDate());
             }
             $this->setOffset($this->getOffset()+1);


### PR DESCRIPTION
After sending the first email the value of the "offset" field is 0. The _getNextDate() implementation then checks the delays with offset 0 and 1, but the configuration delay fields have offset 1, 2 and 3. As such $delayCurrent will be set to null, which causes the $delayReal value to be incorrect. Similarly, after sending the second email the delays will again be wrong, causing a wrong value for the $delayReal variable.

This fix changes the lines that read the config so that the correct values are retrieved. In addition there is a check not to update the mail_scheduled_at field after sending the last mail, as that would again access a nonexistent configuration field.