### PR TITLE
Updates the mail_scheduled_at field with a value that is in the expected format for a DB date

### DIFF
--- a/app/code/community/ADM/AbandonedCart/Model/Followup.php
+++ b/app/code/community/ADM/AbandonedCart/Model/Followup.php
@@ -327,12 +327,9 @@ class ADM_AbandonedCart_Model_Followup extends Mage_Core_Model_Abstract
 
         $delayReal = $delayNext-$delayCurrent;
 
-        $date = new Zend_Date($this->getMailScheduledAt());
-        if($delayReal>0) {
-            $date->add($delayReal, Zend_Date::HOUR);
-        }
-
-        return $date;
+        return Mage::app()->getLocale()->date($this->getMailScheduledAt())
+            ->add(max($delayReal, 0), Zend_Date::HOUR)  //Make sure not to add negative delays
+            ->toString(Varien_Date::DATETIME_INTERNAL_FORMAT);
     }
 
 }

--- a/app/code/community/ADM/AbandonedCart/Model/Followup.php
+++ b/app/code/community/ADM/AbandonedCart/Model/Followup.php
@@ -327,7 +327,7 @@ class ADM_AbandonedCart_Model_Followup extends Mage_Core_Model_Abstract
 
         $delayReal = $delayNext-$delayCurrent;
 
-        return Mage::app()->getLocale()->date($this->getMailScheduledAt())
+        return Mage::app()->getLocale()->date($this->getMailScheduledAt(), null, null, false)   //Do not mess with the timezone
             ->add(max($delayReal, 0), Zend_Date::HOUR)  //Make sure not to add negative delays
             ->toString(Varien_Date::DATETIME_INTERNAL_FORMAT);
     }


### PR DESCRIPTION
As the title says, dates must be set in the expected format, otherwise bad things can (and do) happen.